### PR TITLE
Fix WebhookController constructor

### DIFF
--- a/src/Controllers/WebhookController.php
+++ b/src/Controllers/WebhookController.php
@@ -13,7 +13,7 @@ class WebhookController
 
     public function __construct()
     {
-        $this->pdo = Connection::getInstance()->getConnection();
+        $this->pdo = Connection::getInstance()->getPDO();
     }
 
     /**


### PR DESCRIPTION
## Summary
- use `getPDO()` instead of deprecated `getConnection()` in the `WebhookController` constructor

## Testing
- `php -l src/Controllers/WebhookController.php`

------
https://chatgpt.com/codex/tasks/task_e_6877bba497b08326ac21fb0039929302