### PR TITLE
Replace hard-coded currencies with default constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,8 @@ This repository contains a PHP-based web application for managing bookings and r
 3. Configure your web server to serve the PHP files from the repository directories.
 4. Install any PHP dependencies into the `vendor/` directory if using Composer.
 
+## Currency configuration
+
+All Stripe transactions use the currency defined by the `DEFAULT_CURRENCY` constant in `src/config.php`. Update that constant to change the application's default currency. If you need to support different currencies for specific flows, introduce additional constants in `config.php` and reference them where required.
+
 This project does not include detailed deployment scripts, but the above steps outline the general setup required to run the application locally or on a server.

--- a/booking/checkout_quote.php
+++ b/booking/checkout_quote.php
@@ -40,7 +40,7 @@ try {
         'payment_method_types' => ['card'],
         'line_items' => [[
             'price_data' => [
-                'currency'    => 'aud',
+                'currency'    => DEFAULT_CURRENCY,
                 'unit_amount' => intval(round($bookingValue * 100)), // em centavos
                 'product_data' => [
                     'name'        => $serviceName,

--- a/booking/profile.php
+++ b/booking/profile.php
@@ -130,7 +130,7 @@ HTML;
             'mode'                 => 'payment',
             'line_items'           => [[
                 'price_data' => [
-                    'currency'     => 'usd',
+                    'currency'     => DEFAULT_CURRENCY,
                     'unit_amount'  => intval($breakFee * 100),
                     'product_data' => [
                         'name' => "Multa quebra booking #{$bookingId}"

--- a/src/Controllers/StripeController.php
+++ b/src/Controllers/StripeController.php
@@ -30,7 +30,7 @@ class StripeController {
 
         // Dados do produto
         $priceData = [
-            'currency'     => 'aud',
+            'currency'     => DEFAULT_CURRENCY,
             'product_data' => [
                 'name' => 'Service Booking: ' . $booking['execution_date'],
             ],


### PR DESCRIPTION
## Summary
- update Stripe calls to use `DEFAULT_CURRENCY`
- explain currency configuration in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a43735ba4832699e502e9e798c099