### PR TITLE
Fix cancelled spelling and add booking status constants

### DIFF
--- a/booking/profile.php
+++ b/booking/profile.php
@@ -46,7 +46,10 @@ if (isset($_GET['paid'], $_GET['booking_id']) && $_GET['paid'] === '1') {
         $bookingModel->updateBreakFee($paidBookingId, $breakFee);
         
         // atualiza status no banco
-        $bookingModel->updateRecurrenceStatus($paidBookingId, 'canceled');
+        $bookingModel->updateRecurrenceStatus(
+            $paidBookingId,
+            Booking::RECURRENCE_STATUS_CANCELLED
+        );
         $success = 'Multa paga com sucesso! Sua assinatura será cancelada ao fim do período atual.';
     }
 }
@@ -194,7 +197,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && empty($_POST['cancel_subscription']
 $activeRecurringBooking = null;
 $bookings = $bookingModel->getAllByCustomer($customerId);
 foreach ($bookings as $b) {
-    if (!empty($b['stripe_subscription_id']) && ($b['recurrence_status'] ?? '') === 'active') {
+    if (
+        !empty($b['stripe_subscription_id']) &&
+        ($b['recurrence_status'] ?? '') === Booking::RECURRENCE_STATUS_ACTIVE
+    ) {
         $activeRecurringBooking = $b;
         break;
     }

--- a/src/Controllers/WebhookController.php
+++ b/src/Controllers/WebhookController.php
@@ -34,7 +34,10 @@ class WebhookController
         // 1) Fluxo de cancelamento de multa
         if ($action === 'cancel_break_fee' && $bookingId && $subscriptionId) {
             Subscription::update($subscriptionId, ['cancel_at_period_end' => true]);
-            (new Booking())->updateRecurrenceStatus($bookingId, 'cancelled');
+            (new Booking())->updateRecurrenceStatus(
+                $bookingId,
+                Booking::RECURRENCE_STATUS_CANCELLED
+            );
             return;
         }
 
@@ -42,7 +45,7 @@ class WebhookController
         if ($bookingId && $subscriptionId) {
             $b = new Booking();
             $b->updateSubscriptionId($bookingId, $subscriptionId);
-            $b->updateStatus($bookingId, 'scheduled');
+            $b->updateStatus($bookingId, Booking::STATUS_SCHEDULED);
             return;
         }
 
@@ -104,9 +107,9 @@ class WebhookController
 
         $remaining = $b->getRemainingExecutions($bookingId);
         if ($remaining > 0) {
-            $b->updateStatus($bookingId, 'scheduled');
+            $b->updateStatus($bookingId, Booking::STATUS_SCHEDULED);
         } else {
-            $b->updateStatus($bookingId, 'completed');
+            $b->updateStatus($bookingId, Booking::STATUS_COMPLETED);
         }
     }
 
@@ -131,7 +134,7 @@ class WebhookController
         }
 
         $b = new Booking();
-        $b->updateStatus($bookingId, 'pending');
+        $b->updateStatus($bookingId, Booking::STATUS_PENDING);
     }
 
     /**
@@ -143,7 +146,10 @@ class WebhookController
     {
         error_log("🔍 [subscriptionCancelled] subscription_id={$subscriptionId}");
         $b = new Booking();
-        $b->updateRecurrenceStatusBySubscription($subscriptionId, 'cancelled');
+        $b->updateRecurrenceStatusBySubscription(
+            $subscriptionId,
+            Booking::RECURRENCE_STATUS_CANCELLED
+        );
     }
 
     /**

--- a/src/Models/Booking.php
+++ b/src/Models/Booking.php
@@ -8,6 +8,18 @@ use Src\Database\Connection;
 class Booking {
     protected PDO $db;
 
+    // General booking statuses
+    public const STATUS_PENDING   = 'pending';
+    public const STATUS_PAID      = 'paid';
+    public const STATUS_SCHEDULED = 'scheduled';
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_FAILED    = 'failed';
+
+    // Recurrence statuses
+    public const RECURRENCE_STATUS_ACTIVE    = 'active';
+    public const RECURRENCE_STATUS_PAUSED    = 'paused';
+    public const RECURRENCE_STATUS_CANCELLED = 'cancelled';
+
     public function __construct() {
         $this->db = Connection::getInstance()->getPDO();
     }


### PR DESCRIPTION
## Summary
- replace `'canceled'` with `'cancelled'` in booking/profile.php
- add status constants to `Booking` model
- use new constants in profile and webhook handlers

## Testing
- `php -l booking/profile.php`
- `php -l src/Models/Booking.php`
- `php -l src/Controllers/WebhookController.php`


------
https://chatgpt.com/codex/tasks/task_e_687a43675dbc8326a7b94d73ca6e57d6