### PR TITLE
Ensure single coupon field

### DIFF
--- a/booking/assets/js/discountformbridge.js
+++ b/booking/assets/js/discountformbridge.js
@@ -2,10 +2,11 @@ document.addEventListener("DOMContentLoaded", () => {
   const input           = document.getElementById("discountCode");
   const applyBtn        = document.getElementById("applyDiscountBtn");
   const hiddenInput     = document.getElementById("hiddenCouponCode");
+  const bookingForm     = document.getElementById("bookingForm");
   const totalLabel      = document.querySelector(".summary-total");
   const modalTotalLabel = document.getElementById("totalPriceLabel");
 
-  if (!input || !applyBtn || !hiddenInput || !totalLabel || !modalTotalLabel) return;
+  if (!input || !applyBtn || !hiddenInput || !bookingForm || !totalLabel || !modalTotalLabel) return;
 
   applyBtn.addEventListener("click", () => {
     const code = input.value.trim();
@@ -39,7 +40,13 @@ document.addEventListener("DOMContentLoaded", () => {
       })
       .catch(() => {
         alert("⚠️ Não foi possível validar o cupom. Tente novamente.");
-        hiddenInput.value = "";
-      });
+      hiddenInput.value = "";
+    });
+  });
+
+  bookingForm.addEventListener("submit", () => {
+    if (hiddenInput.value === "") {
+      hiddenInput.value = input.value.trim();
+    }
   });
 });

--- a/booking/booking.php
+++ b/booking/booking.php
@@ -344,9 +344,8 @@ $recurrence = $_POST['recurrence']
             </div>
 
             <!-- ▸ Hidden fields -->
-            <input type="hidden" name="discountCode"   id="hiddenDiscountCode" value="">
+            <input type="hidden" name="discountCode"   id="hiddenCouponCode" value="">
             <input type="hidden" name="pointsApplied"  id="hiddenPointsApplied" value="">
-            <input type="hidden" id="hiddenCouponCode" name="discountCode">
             <input type="hidden" name="baseTotal"      id="baseTotalInput">
         </form>
     </div>
@@ -403,7 +402,6 @@ $recurrence = $_POST['recurrence']
                             >
                             <button type="button" id="applyDiscountBtn" class="apply-btn">Add</button>
                         </div>
-                        <input type="hidden" id="hiddenCouponCode" name="hiddenCouponCode">
                     </div>
 
                     <!-- Points -->


### PR DESCRIPTION
## Summary
- streamline hidden coupon field in booking form
- remove extra coupon field from summary modal
- keep hidden field synced on form submit

## Testing
- `php -l booking/booking.php`
- `node --check booking/assets/js/discountformbridge.js`

------
https://chatgpt.com/codex/tasks/task_e_687a637efd648326920d955a434ee5e8