### PR TITLE
Add coupon and points tracking for bookings

### DIFF
--- a/booking/process_booking.php
+++ b/booking/process_booking.php
@@ -171,6 +171,7 @@ $booking = $bookingModel->create([
     'longitude'           => $input['longitude'],
     'total_price'         => $totalPrice,
     'coupon_code'         => $validCouponCode,
+    'points_used'        => $pointsApplied,
     'status'              => 'pending',
 ]);
 

--- a/src/Models/Booking.php
+++ b/src/Models/Booking.php
@@ -42,9 +42,9 @@ class Booking {
                 INSERT INTO bookings
                     (customer_id, service_id, recurrence, execution_date,
                      start_time, end_time, recurrence_interval,
-                     address, postcode, latitude, longitude,
+                     address, postcode, latitude, longitude, coupon_code, points_used,
                      total_price, status, contract_length, remaining_executions, num_days)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ");
             $stmt->execute([
                 $data['customer_id'],
@@ -58,6 +58,8 @@ class Booking {
                 $data['postcode'],
                 $data['latitude'],
                 $data['longitude'],
+                $data['coupon_code'] ?? null,
+                $data['points_used'] ?? 0,
                 $data['total_price'],
                 $data['status'],
                 $data['contract_length'],


### PR DESCRIPTION
## Summary
- track coupon_code and points_used when creating bookings
- pass points_used from booking processing script

## Testing
- `php -l src/Models/Booking.php`
- `php -l booking/process_booking.php`

------
https://chatgpt.com/codex/tasks/task_e_687a66b1fbc08326a9618d4b60d3bf55