### PR TITLE
Fix booking insert placeholder count

### DIFF
--- a/src/Models/Booking.php
+++ b/src/Models/Booking.php
@@ -44,7 +44,7 @@ class Booking {
                      start_time, end_time, recurrence_interval,
                      address, postcode, latitude, longitude, coupon_code, points_used,
                      total_price, status, contract_length, remaining_executions, num_days)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ");
             $stmt->execute([
                 $data['customer_id'],


### PR DESCRIPTION
## Summary
- ensure `create` query lists 18 placeholders

## Testing
- `php -l src/Models/Booking.php`


------
https://chatgpt.com/codex/tasks/task_e_687a69bc56848326b7ff05f92eb44680