### PR TITLE
Fix coupon code duplication in booking form

### DIFF
--- a/booking/booking.php
+++ b/booking/booking.php
@@ -403,7 +403,6 @@ $recurrence = $_POST['recurrence']
                             >
                             <button type="button" id="applyDiscountBtn" class="apply-btn">Add</button>
                         </div>
-                        <input type="hidden" id="hiddenCouponCode" name="hiddenCouponCode">
                     </div>
 
                     <!-- Points -->


### PR DESCRIPTION
## Summary
- remove duplicate hidden input for coupon code in booking modal

## Testing
- `grep -n "hiddenCouponCode" -n booking/booking.php`

------
https://chatgpt.com/codex/tasks/task_e_687a8e06d3648326a3e8eafefd027ced